### PR TITLE
Rename input control_denoising_strength

### DIFF
--- a/html/templates/main/template-control-params.html
+++ b/html/templates/main/template-control-params.html
@@ -427,7 +427,7 @@
                                 <div class="flexbox col group">
                                     <div data-parent-selector="#tab_control" data-selector="#control_show_preview" class="portal only-diffusers"></div>
                                     <div data-parent-selector="#tab_control" data-selector="#control_input_type" class="portal only-diffusers"></div>
-                                    <div data-parent-selector="#tab_control" data-selector="#control_denoising_strength" class="portal only-diffusers"></div>
+                                    <div data-parent-selector="#tab_control" data-selector="#control_input_denoising_strength" class="portal only-diffusers"></div>
                                 </div>
 
                                 <div class="flexbox col spacer-group"></div>


### PR DESCRIPTION
Hires denoise strenght and control input denoise strenght is conflicting.
Both of them has element_id=control_denoising_strength and hires one gets ignored.

This PR renames input one to control_input_denoising_strength.