### PR TITLE
Add `color-scheme: dark` to applicable themes

### DIFF
--- a/themes/Aptro-AmberGlow.css
+++ b/themes/Aptro-AmberGlow.css
@@ -52,6 +52,8 @@
     --sd-gap-size-val: 5px;
     --sd-outside-gap-size: 8px;
     --sd-gap-size: max(var(--sd-gap-size-val), var(--sd-border-size));
+
+    color-scheme: dark;
 }
 
 /* text features */

--- a/themes/BrknSoul-Amstrad.css
+++ b/themes/BrknSoul-Amstrad.css
@@ -25,7 +25,7 @@ label > span {
 }
 
 h2 {
-    font-family: 'Amstrad-Mode1', 'Courier New', Courier, monospace;    
+    font-family: 'Amstrad-Mode1', 'Courier New', Courier, monospace;
     font-size: 16px;
 }
 
@@ -44,8 +44,10 @@ h2 {
     --sd-panel-border-color:rgba(255,255,0, 0.25);
     --sd-group-background-color:transparent;
     --sd-group-border-color:transparent;
-    
+
     --sd-border-size: 1px;
     --sd-input-border-size: 1px;
+
+    color-scheme: dark;
 }
 

--- a/themes/Default.css
+++ b/themes/Default.css
@@ -39,4 +39,6 @@
   --sd-button-selected-text-color: var(--sd-input-hover-text-color);
   --sd-button-hover-color: var(--sd-button-selected-color);
   --sd-button-hover-text-color: var(--sd-button-selected-text-color);
+
+  color-scheme: dark;
 }

--- a/themes/Eoan-Alpha.css
+++ b/themes/Eoan-Alpha.css
@@ -7,14 +7,14 @@
     --sd-input-secondary-text-color:var(--sd-input-text-color);
     --sd-input-placeholder-text-color:rgba(255, 255, 255, 0.35);
     --sd-input-hover-text-color:var(--sd-input-text-color);
-    
+
     --sd-button-normal-color:var(--sd-input-background-color);
     --sd-button-normal-text-color:var(--sd-input-text-color);
     --sd-button-selected-color:var(--sd-main-accent-color);
     --sd-button-selected-text-color:var(--sd-input-hover-text-color);
     --sd-button-hover-color:var(--sd-button-selected-color);
     --sd-button-hover-text-color:var(--sd-button-selected-text-color);
-    
+
     --sd-main-background-color:rgb(32 32 32);
     --sd-input-background-color:rgba(0, 0, 0, 0.25);
     --sd-input-border-color:rgba(0, 0, 0, 0.1);
@@ -43,4 +43,6 @@
     --sd-gap-size-val:5px;
     --sd-outside-gap-size:8px;
     --sd-gap-size:max(var(--sd-gap-size-val), var(--sd-border-size));
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Cyan.css
+++ b/themes/Eoan-Cyan.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(225deg 6% 13%);
     --sd-group-gap:5px;
     --sd-outside-gap-size:8px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Green.css
+++ b/themes/Eoan-Green.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(225deg 6% 13%);
     --sd-group-gap:5px;
     --sd-outside-gap-size:8px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Minimal.css
+++ b/themes/Eoan-Minimal.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(240deg 16% 16%);
     --sd-group-gap:2px;
     --sd-outside-gap-size:1px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Moonlight.css
+++ b/themes/Eoan-Moonlight.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(240deg 16% 16%);
     --sd-group-gap:2px;
     --sd-outside-gap-size:8px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Orange.css
+++ b/themes/Eoan-Orange.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(225deg 6% 13%);
     --sd-group-gap:2px;
     --sd-outside-gap-size:8px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-OrangeMinimal.css
+++ b/themes/Eoan-OrangeMinimal.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(240deg 16% 16%);
     --sd-group-gap:2px;
     --sd-outside-gap-size:4px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-OrangeMoonlight.css
+++ b/themes/Eoan-OrangeMoonlight.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(30deg 16% 16%);
     --sd-group-gap:1px;
     --sd-outside-gap-size:8px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Quad.css
+++ b/themes/Eoan-Quad.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(240deg 16% 16%);
     --sd-group-gap:1px;
     --sd-outside-gap-size:8px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Subdued.css
+++ b/themes/Eoan-Subdued.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(225deg 6% 13%);
     --sd-group-gap:5px;
     --sd-outside-gap-size:8px;
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Tron.css
+++ b/themes/Eoan-Tron.css
@@ -28,4 +28,6 @@
     --sd-input-text-color:hsl(168deg 75% 70%);
     --sd-input-placeholder-text-color:hsl(185deg 72% 25%);
     --sd-input-hover-text-color:hsl(182deg 94% 80%);
+
+    color-scheme: dark;
 }

--- a/themes/Eoan-Yellow.css
+++ b/themes/Eoan-Yellow.css
@@ -28,4 +28,6 @@
     --sd-input-text-color:hsl(58deg 39% 50%);
     --sd-input-placeholder-text-color:hsl(185deg 72% 25%);
     --sd-input-hover-text-color:hsl(184deg 89% 7%);
+
+    color-scheme: dark;
 }

--- a/themes/IlluZn-Domination.css
+++ b/themes/IlluZn-Domination.css
@@ -47,6 +47,8 @@
     --sd-gap-size-val: 5px;
     --sd-outside-gap-size: 8px;
     --sd-gap-size: max(var(--sd-gap-size-val), var(--sd-border-size));
+
+    color-scheme: dark;
 }
 
 /* Accents generate button :D */

--- a/themes/IlluZn-LavenderZest.css
+++ b/themes/IlluZn-LavenderZest.css
@@ -49,6 +49,8 @@
     --sd-gap-size-val: 5px;
     --sd-outside-gap-size: 8px;
     --sd-gap-size: max(var(--sd-gap-size-val), var(--sd-border-size));
+
+    color-scheme: dark;
 }
 
 /* Accents generate button :D */

--- a/themes/IlluZn-Superuser.css
+++ b/themes/IlluZn-Superuser.css
@@ -49,6 +49,8 @@
     --sd-gap-size-val: 5px;
     --sd-outside-gap-size: 8px;
     --sd-gap-size: max(var(--sd-gap-size-val), var(--sd-border-size));
+
+    color-scheme: dark;
 }
 
 /* Accents generate button :D */

--- a/themes/IlluZn-VintageBeige.css
+++ b/themes/IlluZn-VintageBeige.css
@@ -49,6 +49,8 @@
     --sd-gap-size-val: 5px;
     --sd-outside-gap-size: 8px;
     --sd-gap-size: max(var(--sd-gap-size-val), var(--sd-border-size));
+
+    color-scheme: dark;
 }
 
 /* Accents generate button :D */

--- a/themes/QS-Sunset.css
+++ b/themes/QS-Sunset.css
@@ -18,4 +18,6 @@
     --sd-button-normal-color: #B51B75;
     --sd-button-hover-color: #F8D082;
     --sd-button-hover-text-color: #E65C19;
+
+    color-scheme: dark;
 }

--- a/themes/QS-Teal.css
+++ b/themes/QS-Teal.css
@@ -14,7 +14,9 @@
     --sd-panel-border-color:rgba(255,255,255, 0.15);
     --sd-group-background-color:transparent;
     --sd-group-border-color:transparent;
-    
+
     --sd-border-size: 1px;
     --sd-input-border-size: 1px;
+
+    color-scheme: dark;
 }

--- a/themes/QS-WhiteRabbit.css
+++ b/themes/QS-WhiteRabbit.css
@@ -24,10 +24,12 @@
     --sd-panel-background-color: #ffffff0a;
     --sd-panel-border-color: transparent;
     --sd-group-background-color: hsla(0, 0%, 0%, 0.15);
-    
+
     --sd-scrollbar-color: #0f02;
     --sd-outline-color: #0f07;
     --sd-outline-size: 0.01px;
+
+    color-scheme: dark;
 }
 
 h2, label {

--- a/themes/Vlad-Default.css
+++ b/themes/Vlad-Default.css
@@ -39,4 +39,6 @@
   --sd-button-selected-text-color: var(--sd-input-hover-text-color);
   --sd-button-hover-color: var(--sd-button-selected-color);
   --sd-button-hover-text-color: var(--sd-button-selected-text-color);
+
+  color-scheme: dark;
 }

--- a/themes/Vlad-Flat.css
+++ b/themes/Vlad-Flat.css
@@ -30,4 +30,6 @@
     --sd-group-border-color:hsl(225deg 6% 12%);
     --sd-group-gap:0;
     --sd-outside-gap-size:8px;
+
+    color-scheme: dark;
 }


### PR DESCRIPTION
## Description

Adds the `color-scheme: dark` CSS property to dark themes, to style checkboxes, radio buttons and `<input type="number">` spin buttons

## Notes

I did it to only the themes where I thought it would make sense, but for some of them that choice's kinda arbitrary.
If checkboxes and radio buttons are fully customized in the future, I think it still makes sense to keep these changes since they work on the `<input type="number">` spin buttons, which are otherwise unstyleable at all

## Environment and Testing

Windows 11, Firefox 127.0. I have no idea how the development pipeline works here, so to test the themes I removed the original extension's folder from `extensions-builtin` and made a symlink to my version in its place.
