### PR TITLE
Update style.css for expandable hints & enhanced look of hints

### DIFF
--- a/style.css
+++ b/style.css
@@ -2155,6 +2155,7 @@ div#layout-3 {
   color: darkred;
   content: attr(error-count);
   font-size: 0.8em;
+  padding: 0 0.5em;
   position: absolute;
   right: -0.2em;
   top: -0.2em;
@@ -4448,6 +4449,7 @@ input[type="range"]::-ms-fill-upper {
   display: block;
   font-size: 1.0em;
   min-height: 1.3em;
+  max-width: 40em;
   opacity: 0;
   padding: 0.5em;
   pointer-events: none;
@@ -4458,15 +4460,89 @@ input[type="range"]::-ms-fill-upper {
   width: 22em;
   z-index: 999;
   border-radius: var(--sd-border-radius);
+  overflow: visible;
 }
 
 .tooltip-show {
   opacity: 0.9;
 }
 
+.tooltip-expanded {
+  width: 32em;
+}
+
 .tooltip-left {
   left: 0.5em;
   right: unset;
+}
+
+.tooltip .separator {
+  display: block;
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--sd-input-border-color), transparent);
+  margin: 0.5em 0;
+  opacity: 0.6;
+}
+
+.tooltip .long-content {
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition: opacity 0.3s ease-in, max-height 0.3s ease-in-out;
+}
+
+.tooltip .long-content.show {
+  opacity: 1;
+  max-height: 50em;
+}
+
+.tooltip-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tooltip-progress-ring {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+  transition: opacity 0.2s ease-in;
+}
+
+.tooltip-progress-ring.active {
+  opacity: 0.8;
+}
+
+.tooltip-progress-ring svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.tooltip-progress-ring .ring-background {
+  fill: none;
+  stroke: var(--sd-input-border-color);
+  stroke-width: 2;
+  opacity: 0.3;
+}
+
+.tooltip-progress-ring .ring-progress {
+  fill: none;
+  stroke: var(--sd-tooltip-text-color);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-dasharray: 44; /* Circumference of circle with radius 7 (2πr = 2π×7 ≈ 44) */
+  stroke-dashoffset: 44;
+  transition: stroke-dashoffset 3s linear;
+}
+
+.tooltip-progress-ring .ring-progress.animate {
+  stroke-dashoffset: 0;
 }
 
 .toolbutton-selected {


### PR DESCRIPTION
Update modernUI to work with my commit for expandable hints & enhanced look of hints.

## Description

Make the updated tooltips work with modernUI.

## Notes

I think it's quite straightforward, simple additions.

## Environment and Testing

Edge and Firefox, on both Standard and ModernUIs in all themes to look for conflicts.
